### PR TITLE
chore: change license text and link

### DIFF
--- a/src/courseware/course/course-license/CourseLicense.jsx
+++ b/src/courseware/course/course-license/CourseLicense.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -105,6 +106,7 @@ function parseLicense(license) {
 
 function CourseLicense({
   license,
+  courseId,
   intl,
 }) {
   const renderAllRightsReservedLicense = () => (
@@ -119,7 +121,7 @@ function CourseLicense({
       className="text-decoration-none text-gray-500"
       rel="license noopener noreferrer"
       target="_blank"
-      href={`https://creativecommons.org/licenses/${activeCreativeCommonsLicenseTags.join('-')}/${version}/`}
+      href={`${getConfig().LMS_BASE_URL}/courses/${courseId}/about`}
     >
       <span className="sr-only">
         {intl.formatMessage(messages['learn.course.license.creativeCommons.terms.preamble'])}&nbsp;
@@ -133,10 +135,9 @@ function CourseLicense({
           <FontAwesomeIcon aria-hidden="true" className="mr-1" icon={CreativeCommonsLicenseTags[tag].icon} />
         </span>
       ))}
-      {intl.formatMessage(messages['learn.course.license.creativeCommons.text'])}
+      {activeCreativeCommonsLicenseTags.includes('sa') ? `${intl.formatMessage(messages['learn.course.license.creativeCommons.shareAlike.text'])} ${version}` : intl.formatMessage(messages['learn.course.license.creativeCommons.text'])}
     </a>
   );
-
   const [licenseType, licenseOptions, licenseVersion] = parseLicense(license);
 
   return (
@@ -152,6 +153,7 @@ function CourseLicense({
 
 CourseLicense.propTypes = {
   license: PropTypes.string,
+  courseId: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
 };
 

--- a/src/courseware/course/course-license/messages.js
+++ b/src/courseware/course/course-license/messages.js
@@ -40,7 +40,12 @@ const messages = defineMessages({
   'learn.course.license.creativeCommons.text': {
     id: 'learn.course.license.creativeCommons.text',
     defaultMessage: 'Some Rights Reserved',
-    description: 'License text shown when using all Creative Commons license types.',
+    description: 'License text shown when using Creative Commons license types.',
+  },
+  'learn.course.license.creativeCommons.shareAlike.text': {
+    id: 'learn.course.license.creativeCommons.shareAlike.text',
+    defaultMessage: 'CC-by-sa',
+    description: 'License text shown when using share-alike Creative Commons license types.',
   },
 });
 

--- a/src/courseware/course/sequence/Sequence.jsx
+++ b/src/courseware/course/sequence/Sequence.jsx
@@ -249,7 +249,7 @@ function Sequence({
         >
           {defaultContent}
         </SequenceExamWrapper>
-        <CourseLicense license={course.license || undefined} />
+        <CourseLicense license={course.license || undefined} courseId={courseId} />
       </div>
     );
   }


### PR DESCRIPTION
Changes the license text from "Some rights reserved" to "CC-by-sa 4.0" for creative common share-alike licenses.