### PR TITLE
fix: prevent crash when courseMetadataResult is undefined by optional chaining

### DIFF
--- a/src/courseware/data/thunks.js
+++ b/src/courseware/data/thunks.js
@@ -151,7 +151,7 @@ export function fetchCourse(courseId) {
         } = mergeLearningSequencesWithCourseBlocks(
           learningSequencesOutlineResult.value,
           courseBlocksResult.value,
-          courseMetadataResult.value.isMasquerading,
+          courseMetadataResult.value?.isMasquerading,
         );
 
         // This updates the course with a sectionIds array from the blocks data.


### PR DESCRIPTION
Fixes: https://github.com/wikimedia/edx-platform/issues/505